### PR TITLE
Fix bug with async middlewares not properly catched

### DIFF
--- a/lib/chainexecutor.js
+++ b/lib/chainexecutor.js
@@ -14,11 +14,8 @@ function create(fcts, callback){
 		}
 		if ( f.length === 3 ) {
 			const up = (req, res) => new Promise( resolve => {
-				try {
-					f(req, res, resolve);
-				} catch(e){
-					resolve(e);
-				}
+				Promise.resolve(f(req, res, resolve))
+				.catch(resolve);
 			});
 			Object.defineProperty(up, "name", { value: f.name });
 			logger.debug(`#${i}: ${f.name} (converted in normal handler)`);
@@ -26,11 +23,8 @@ function create(fcts, callback){
 		}
 		if ( f.length === 4 ) {
 			const up = (err, req, res) => new Promise( resolve => {
-				try {
-					f(err, req, res, resolve);
-				} catch(e){
-					resolve(e);
-				}
+				Promise.resolve(f(err, req, res, resolve))
+				.catch(resolve);
 			});
 			Object.defineProperty(up, "name", { value: f.name });
 			logger.debug(`#${i}: ${up.name} (converted in error handler)`);


### PR DESCRIPTION
`try/catch` does not properly catch errors from async middlewares (error is unhandled and breaks chain execution).

`Promise.resolve()` wrapping the middleware function will ensure that regardless of being sync or async they will be turned to async ones. `Promise.resolve()` will **NOT** transform rejected promises to resolved ones. It just wraps the result.